### PR TITLE
DRAFT: Add context to VXC WaitFor* functions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Tests can be executed for this library by running `make integration` to run all 
 * port-integ
 * vxc-integ
 
-In order to run theses tests valid user Credentials will need to be provided as per the Credentials section below.
+In order to run these tests valid user Credentials will need to be provided as per the Credentials section below.
 
 ### Credentials
 For the purposes of testing Megaport Credentials can be passed to the integration tests by setting the following environment variables:

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,17 @@
 module github.com/megaport/megaportgo
 
-go 1.13
+go 1.20
 
 require (
 	github.com/lithammer/fuzzysearch v1.1.5
-	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/stretchr/testify v1.7.2
 	github.com/xlzd/gotp v0.0.0-20220110052318-fab697c03c2c
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.4.0 // indirect
+	golang.org/x/text v0.3.8 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -13,7 +13,6 @@ github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/xlzd/gotp v0.0.0-20220110052318-fab697c03c2c h1:LZpKQbMSngtN4ycCtogkxYl5ec0FimAA8rSrI4ZMGTM=
 github.com/xlzd/gotp v0.0.0-20220110052318-fab697c03c2c/go.mod h1:ndLJ3JKzi3xLmUProq4LLxCuECL93dG9WASNLpHz8qg=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/xlzd/gotp v0.0.0-20220110052318-fab697c03c2c h1:LZpKQbMSngtN4ycCtogkx
 github.com/xlzd/gotp v0.0.0-20220110052318-fab697c03c2c/go.mod h1:ndLJ3JKzi3xLmUProq4LLxCuECL93dG9WASNLpHz8qg=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
+golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/service/vxc/partner.go
+++ b/service/vxc/partner.go
@@ -17,7 +17,7 @@ package vxc
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/megaport/megaportgo/mega_err"
@@ -33,14 +33,14 @@ const PARTNER_AWS string = "AWS"
 func (v *VXC) LookupPartnerPorts(key string, portSpeed int, partner string, requestedProductID string) (string, error) {
 	lookupUrl := "/v2/secure/" + strings.ToLower(partner) + "/" + key
 	response, resErr := v.Config.MakeAPICall("GET", lookupUrl, nil)
-	defer response.Body.Close()
 	isErr, compiledErr := v.Config.IsErrorResponse(response, &resErr, 200)
 
 	if isErr {
 		return "", compiledErr
 	}
+	defer func(Body io.ReadCloser) { _ = Body.Close() }(response.Body)
 
-	body, fileErr := ioutil.ReadAll(response.Body)
+	body, fileErr := io.ReadAll(response.Body)
 
 	if fileErr != nil {
 		return "", fileErr
@@ -68,7 +68,7 @@ func (v *VXC) LookupPartnerPorts(key string, portSpeed int, partner string, requ
 	return "", errors.New(mega_err.ERR_NO_AVAILABLE_VXC_PORTS)
 }
 
-// BuyAWSVXC buys an AWS VXC.
+// BuyPartnerVXC buys a partner VXC.
 func (v *VXC) BuyPartnerVXC(
 	portUID string,
 	vxcName string,
@@ -109,8 +109,8 @@ func (v *VXC) BuyPartnerVXC(
 	return orderInfo.Data[0].TechnicalServiceUID, nil
 }
 
-// BuyPartnerVXC performs Step 2 of the partner port purchase process. These are for partners that require some kind
-// of partner pairing key (e.g. GCP, Azure).
+// MarshallPartnerConfig performs Step 2 of the partner port purchase process. These are for partners that require
+// some kind of partner pairing key (e.g. GCP, Azure).
 func (v *VXC) MarshallPartnerConfig(
 	key string,
 	partner string,


### PR DESCRIPTION
Using a context allows for the caller to specify the timeouts it is
willing to accept, and also pass through user cancellation to better
manage resources.

Corrects a couple godocs and go fmt / compiler warnings